### PR TITLE
Created method which will get the correct name for javaBean properties...

### DIFF
--- a/generator/src/com/liferay/alloy/tools/builder/templates/faces/component_base.ftl
+++ b/generator/src/com/liferay/alloy/tools/builder/templates/faces/component_base.ftl
@@ -29,13 +29,13 @@ public abstract class ${component.getCamelizedName()}Base extends ${component.ge
 
 	<#list component.getAttributesAndEvents() as attribute>
 	<#if attribute.isGettable()>
-	public ${attribute.getJSFInputType()} get${attribute.getCapitalizedName()}() {
+	public ${attribute.getJSFInputType()} get${attribute.getJavaBeanPropertyName()}() {
 		return (${attribute.getJSFInputType()}) getStateHelper().eval(${attribute.getConstantName()}, null);
 	}
 	</#if>
 
 	<#if attribute.isSettable()>
-	public void set${attribute.getCapitalizedName()}(${attribute.getJSFInputType()} ${attribute.getJavaSafeName()}) {
+	public void set${attribute.getJavaBeanPropertyName()}(${attribute.getJSFInputType()} ${attribute.getJavaSafeName()}) {
 		getStateHelper().put(${attribute.getConstantName()}, ${attribute.getJavaSafeName()});
 	}
 

--- a/generator/src/com/liferay/alloy/tools/builder/templates/faces/renderer_base.ftl
+++ b/generator/src/com/liferay/alloy/tools/builder/templates/faces/renderer_base.ftl
@@ -59,7 +59,7 @@ public abstract class ${component.getCamelizedName()}RendererBase extends Render
 
 		<#list component.getAttributes() as attribute>
 		<#if attribute.isGettable()>
-		${attribute.getJSFInputType()} ${attribute.getJavaSafeName()} = ${component.getUncapitalizedName()}.get${attribute.getCapitalizedName()}();
+		${attribute.getJSFInputType()} ${attribute.getJavaSafeName()} = ${component.getUncapitalizedName()}.get${attribute.getJavaBeanPropertyName()}();
 
 		if (${attribute.getJavaSafeName()} != null) {
 
@@ -83,7 +83,7 @@ public abstract class ${component.getCamelizedName()}RendererBase extends Render
 		isFirst = true;
 
 		<#list component.getAfterEvents() as event>
-		${event.getJSFInputType()} ${event.getJavaSafeName()} = ${component.getUncapitalizedName()}.get${event.getCapitalizedName()}();
+		${event.getJSFInputType()} ${event.getJavaSafeName()} = ${component.getUncapitalizedName()}.get${event.getJavaBeanPropertyName()}();
 
 		if (${event.getJavaSafeName()} != null) {
 
@@ -105,7 +105,7 @@ public abstract class ${component.getCamelizedName()}RendererBase extends Render
 		isFirst = true;
 
 		<#list component.getOnEvents() as event>
-		${event.getJSFInputType()} ${event.getJavaSafeName()} = ${component.getUncapitalizedName()}.get${event.getCapitalizedName()}();
+		${event.getJSFInputType()} ${event.getJavaSafeName()} = ${component.getUncapitalizedName()}.get${event.getJavaBeanPropertyName()}();
 
 		if (${event.getJavaSafeName()} != null) {
 

--- a/generator/src/com/liferay/alloy/tools/model/Attribute.java
+++ b/generator/src/com/liferay/alloy/tools/model/Attribute.java
@@ -41,12 +41,31 @@ public class Attribute extends BaseModel {
 		return _defaultValue;
 	}
 
+	protected String getInferredNamePrefix(String name) {
+
+		// Section 8.8
+		// http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf
+		return name.substring(0, 2);
+	}
+
 	public String getInputType() {
 		return TypeUtil.getInputJavaType(_inputType, true);
 	}
 
 	public String getInputTypeSimpleClassName() {
 		return getTypeSimpleClassName(getRawInputType());
+	}
+
+	public String getJavaBeanPropertyName() {
+
+		String javaBeanPropertyName = getSafeName();
+
+		if (javaBeanPropertyName.length() == 1 || 
+				StringUtils.isAllLowerCase(getInferredNamePrefix(javaBeanPropertyName))) {				
+				javaBeanPropertyName = getCapitalizedName();
+		}
+
+		return javaBeanPropertyName;
 	}
 
 	public String getJavaSafeName() {


### PR DESCRIPTION
...according to the rules of the [JavaBeans spec](http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf) section 8.8. Specifically dealt with the case where the second letter of a property is capitalized and the first is not, which requires that the first letter not be capitalized in the getters and setters for that property.
